### PR TITLE
python: Add patch to disable SOCK_CLOEXEC usage

### DIFF
--- a/patches/0003-Do-not-use-SOCK_CLOEXEC.patch
+++ b/patches/0003-Do-not-use-SOCK_CLOEXEC.patch
@@ -1,0 +1,31 @@
+From 74f063268b19fe3654799eea48cc4d9aa805c13f Mon Sep 17 00:00:00 2001
+From: Vlad Badoiu <vlad_andrei.badoiu@upb.ro>
+Date: Tue, 18 Jan 2022 22:53:47 +0200
+Subject: [PATCH 1/1] Do not use SOCK_CLOEXEC
+
+We do not use SOCK_CLOEXEC in the socketmodule because it
+is not available undr lwip.
+
+Signed-off-by: Vlad Badoiu <vlad_andrei.badoiu@upb.ro>
+---
+ Modules/socketmodule.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Modules/socketmodule.c b/Modules/socketmodule.c
+index 72b122c..e262694 100644
+--- a/Modules/socketmodule.c
++++ b/Modules/socketmodule.c
+@@ -574,6 +574,10 @@ select_error(void)
+ #  define SOCK_INPROGRESS_ERR EINPROGRESS
+ #endif
+ 
++#ifdef SOCK_CLOEXEC
++#undef SOCK_CLOEXEC
++#endif
++
+ #ifdef _MSC_VER
+ #  define SUPPRESS_DEPRECATED_CALL __pragma(warning(suppress: 4996))
+ #else
+-- 
+2.25.1
+


### PR DESCRIPTION
We create a patch that undefines this symbol inside
the posix socket module of Python. We do this because
the functionality is not available under lwip and it
causes an error under Python.

Signed-off-by: Vlad-Andrei Badoiu <vlad_andrei.badoiu@upb.ro>