### PR TITLE
Config.uk: Add dependencies for POSIX libraries

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -13,6 +13,8 @@ menuconfig LIBPYTHON3
 	select LIBSYSCALL_SHIM
 	select LIBVFSCORE
 	select LIBPTHREAD_EMBEDDED
+	select LIBPOSIX_SOCKET
+	select LIBPOSIX_EVENT
 	select LIBLWIP
 	select LWIP_DHCP
 	select LWIP_DNS


### PR DESCRIPTION
Release 0.10 added `posix-socket` and `posix-event` internal libraries to the Unikraft core. Consequently, libraries depending on networking functionality need to be updated to include `posix-socket` and
`posix-event`.

This commit adds `LIBPOSIX_SOCKET` and `LIBPOSIX_EVENT` dependency to `Config.uk`.