### PR TITLE
include/pyconfig.h: Use value 8 for SIZEOF_PTHREAD_T

### DIFF
--- a/include/pyconfig.h
+++ b/include/pyconfig.h
@@ -1381,7 +1381,7 @@
 #define SIZEOF_PTHREAD_KEY_T 4
 
 /* The size of `pthread_t', as computed by sizeof. */
-#define SIZEOF_PTHREAD_T 16
+#define SIZEOF_PTHREAD_T 8
 
 /* The size of `short', as computed by sizeof. */
 #define SIZEOF_SHORT 2


### PR DESCRIPTION
This is the value used by Musl (`sizoef(pthread_t)`), as `pthread_t` is defined as `unsigned long`.