### PR TITLE
include/pyconfig.h: Add guard for `x86` specific macros

### DIFF
--- a/include/pyconfig.h
+++ b/include/pyconfig.h
@@ -390,11 +390,17 @@
 /* #undef HAVE_GCC_ASM_FOR_MC68881 */
 
 /* Define if we can use x64 gcc inline assembler */
+
+#if defined(__x86_64__)
 #define HAVE_GCC_ASM_FOR_X64 1
+#endif
 
 /* Define if we can use gcc inline assembler to get and set x87 control word
    */
+
+#if defined(__x86_64__)
 #define HAVE_GCC_ASM_FOR_X87 1
+#endif
 
 /* Define if your compiler provides __uint128_t */
 #define HAVE_GCC_UINT128_T 1


### PR DESCRIPTION
`HAVE_GCC_ASM_FOR_X64` and `HAVE_GCC_ASM_FOR_X87` macros break the build for `app-python3` on `AArch64`. Therefore, this PR adds an architecture specific guard for each one of them, as on `x86` they behave just fine.

Github-Fixes: #10

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>