### PR TITLE
include/pyconfig.h: Define `SIZEOF_PHTREAD_T` based on chosen libc

### DIFF
--- a/include/pyconfig.h
+++ b/include/pyconfig.h
@@ -1387,7 +1387,11 @@
 #define SIZEOF_PTHREAD_KEY_T 4
 
 /* The size of `pthread_t', as computed by sizeof. */
+#ifdef CONFIG_LIBPTHREAD_EMBEDDED
+#define SIZEOF_PTHREAD_T 12
+#else
 #define SIZEOF_PTHREAD_T 8
+#endif
 
 /* The size of `short', as computed by sizeof. */
 #define SIZEOF_SHORT 2


### PR DESCRIPTION
The size of the `pthread_t` type varies between the libc/posix-threads implementations, so we need to define the `SIZEOF_PTHREAD_T` macro accordingly. This PR implements an additional
check for the Pthread Embedded library.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>