### PR TITLE
Add support for the Shapely extension

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -88,5 +88,11 @@ config LIBPYTHON3_EXTENSION_NUMPY
     default y
 endif
 
+if LIBPYTHON_SHAPELY
+config LIBPYTHON3_EXTENSION_SHAPELY
+    bool "Shapely"
+    default y
+endif
+
 endif
 endif

--- a/modules_config.c
+++ b/modules_config.c
@@ -186,6 +186,14 @@ extern PyObject* PyInit__umath_tests(void);
 /* Numpy end */
 #endif
 
+#if CONFIG_LIBPYTHON3_EXTENSION_SHAPELY
+/* Shapely */
+extern PyObject* PyInit_lib(void);
+extern PyObject* PyInit__geometry_helpers(void);
+extern PyObject* PyInit__geos(void);
+/* Shapely end */
+#endif
+
 struct _inittab _PyImport_Inittab[] = {
 
     {"posix", PyInit_posix},
@@ -382,6 +390,12 @@ struct _inittab _PyImport_Inittab[] = {
     {"numpy_core__struct_ufunc_tests", PyInit__struct_ufunc_tests},
     {"numpy_linalg__umath_linalg", PyInit__umath_linalg},
     {"numpy_core__umath_tests", PyInit__umath_tests},
+#endif
+
+#if CONFIG_LIBPYTHON3_EXTENSION_SHAPELY
+    {"shapely_lib", PyInit_lib},
+    {"shapely__geometry_helpers", PyInit__geometry_helpers},
+    {"shapely__geos", PyInit__geos},
 #endif
 
     /* Sentinel */


### PR DESCRIPTION
This change set adds support for the shapely extension in the main Python build.

Depends on Python 3.10 and Numpy:
- https://github.com/unikraft/lib-python3/pull/15
- https://github.com/unikraft/lib-python3/pull/16
- https://github.com/unikraft/lib-python-numpy/pull/1

and all their dependencies. Contains all commits from https://github.com/unikraft/lib-python3/pull/16.
Commit c26d30d06e19ae76c2c98c18694ad70b85a6b142 adds shapely support. (Will rebase once numpy is mainlined)

The Shapely microlibrary is a separate PR:
- https://github.com/unikraft/lib-python-shapely/pull/1