### PR TITLE
Add support for the Pillow extension

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -94,5 +94,11 @@ config LIBPYTHON3_EXTENSION_SHAPELY
     default y
 endif
 
+if LIBPYTHON_PILLOW
+config LIBPYTHON3_EXTENSION_PILLOW
+    bool "Pillow"
+    default y
+endif
+
 endif
 endif

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -497,7 +497,7 @@ PYTHON_ROOTFS = $(APP_BASE)/$(path)
 $(PYTHON_ROOTFS)/.keep: $(LIBPYTHON3_BUILD)/.origin
 	@test $(LIBPYTHON3_VERSION) = `python -V | cut -d' ' -f2 | cut -d. -f1,2` || \
 		(echo -e "WARNING: creating virtualenv with wrong python version, pip might not work correctly\nPress return to continue" && read)
-	python3 -m venv $(PYTHON_ROOTFS)
+	python -m venv $(PYTHON_ROOTFS)
 	find "$(PYTHON_ROOTFS)" -type d -name '__pycache__' | xargs rm -rf
 	touch $@
 
@@ -516,7 +516,7 @@ $(PYTHON_ROOTFS)/.done: $(PYTHON_ROOTFS)/.configured
 $(PYTHON_ROOTFS)/.compiled: python-rootfs
 	test $(LIBPYTHON3_VERSION) = `python -V | cut -d' ' -f2 | cut -d. -f1,2` || \
 		(echo "ERROR: local Python version is not $(LIBPYTHON3_VERSION), cannot compile .py files" && false)
-	python3 -m compileall -x 'lib2to3/|test/bad' "$(PYTHON_ROOTFS)/lib"
+	python -m compileall -x 'lib2to3/|test/bad' "$(PYTHON_ROOTFS)/lib"
 	touch $@
 
 .PHONY: python-rootfs

--- a/modules_config.c
+++ b/modules_config.c
@@ -194,6 +194,18 @@ extern PyObject* PyInit__geos(void);
 /* Shapely end */
 #endif
 
+#if CONFIG_LIBPYTHON3_EXTENSION_PILLOW
+/* Pillow */
+extern PyObject* PyInit__imaging(void);
+extern PyObject* PyInit__imagingcms(void);
+extern PyObject* PyInit__imagingft(void);
+extern PyObject* PyInit__imagingmath(void);
+extern PyObject* PyInit__imagingmorph(void);
+extern PyObject* PyInit__imagingtk(void);
+extern PyObject* PyInit__webp(void);
+/* Pillow end */
+#endif
+
 struct _inittab _PyImport_Inittab[] = {
 
     {"posix", PyInit_posix},
@@ -396,6 +408,22 @@ struct _inittab _PyImport_Inittab[] = {
     {"shapely_lib", PyInit_lib},
     {"shapely__geometry_helpers", PyInit__geometry_helpers},
     {"shapely__geos", PyInit__geos},
+#endif
+
+#if CONFIG_LIBPYTHON3_EXTENSION_PILLOW
+    {"PIL__imaging", PyInit__imaging},
+#if CONFIG_LIBLITTLECMS
+    {"PIL__imagingcms", PyInit__imagingcms},
+#endif
+#if CONFIG_LIBFREETYPE
+    {"PIL__imagingft", PyInit__imagingft},
+#endif
+    {"PIL__imagingmath", PyInit__imagingmath},
+    {"PIL__imagingmorph", PyInit__imagingmorph},
+    {"PIL__imagingtk", PyInit__imagingtk},
+#if CONFIG_LIBWEBP
+    {"PIL__webp", PyInit__webp},
+#endif
 #endif
 
     /* Sentinel */


### PR DESCRIPTION
This change only adds the necessary module registrations and Kconfig options. Pillow itself is provided by its own Unikraft port.

In addition, contains a hotfix commit to consistently use `python` when building the rootfs (instead of a mix of `python` and `python3`).

Depends on the Pillow port PR:
- https://github.com/unikraft/lib-python-pillow/pull/1

as well as all of its dependencies and interactions.
May also depend on:
- https://github.com/unikraft/lib-libffi/pull/2
- https://github.com/unikraft/unikraft/pull/1071
- https://github.com/unikraft/unikraft/pull/1072 (to fix complaints about wrong file ownership)
- https://github.com/unikraft/unikraft/pull/1073
- https://github.com/unikraft/unikraft/pull/1074
- https://github.com/unikraft/unikraft/pull/1075
- https://github.com/unikraft/lib-libuuid/pull/6
- https://github.com/unikraft/lib-sqlite/pull/8
- https://github.com/unikraft/lib-python-numpy/pull/2
- https://github.com/unikraft/lib-python3/pull/18
- https://github.com/unikraft/lib-python3/pull/19
- https://github.com/unikraft/lib-python3/pull/20
- https://github.com/unikraft/lib-intel-intrinsics/pull/5

Running the Pillow tests:
- configure & build w/ numpy and all possible dependent libraries (see pillow port PR above)
- create rootfs from build configuration
- install `pytest` in rootfs (via venv + pip)
- copy `$(BUILD_DIR)/lib-python-pillow/origin/Pillow-10.0.0/Tests` over into the rootfs
- run Python unikernel w/ `-m pytest Tests/` with plenty of allocated VM RAM
  - on RAMfs/initrd root: expect at most some complaints about missing fork/exec
  - on 9Pfs root: like ramfs + one outright bemusing failure where some compressed tiffs are saved larger than uncompressed; images are OK, uncorrupted; _no clue_ why it happens, even less so why _only on 9P_. I currently blame it on computer gremlins; free cake for who can figure out the root cause.